### PR TITLE
简单思路--关于access-token在http过程失效，retry机制

### DIFF
--- a/apis/oauth/oauth.go
+++ b/apis/oauth/oauth.go
@@ -69,6 +69,8 @@ func GetAuthorizeUrl(appid string, redirectUri string, scope string, state strin
 	params.Add("redirect_uri", redirectUri)
 	params.Add("scope", scope)
 	params.Add("state", state)
+	params.Add("response_type", "code")
+
 	return OauthAuthorizeServerUrl + apiAuthorize + "?" + params.Encode()
 }
 
@@ -94,6 +96,7 @@ func GetAccessToken(appid string, secret string, code string) (oauthAccessToken 
 	params.Add("appid", appid)
 	params.Add("secret", secret)
 	params.Add("code", code)
+	params.Add("grant_type", "authorization_code")
 
 	uri := offiaccount.WXServerUrl + apiAccessToken + "?" + params.Encode()
 	response, err := http.Get(uri)
@@ -161,7 +164,7 @@ const (
 type OauthUserInfo struct {
 	Openid     string   `json:"openid"`
 	Nickname   string   `json:"nickname"`
-	Sex        string   `json:"sex"`
+	Sex        int      `json:"sex"`
 	Province   string   `json:"province"`
 	City       string   `json:"city"`
 	Country    string   `json:"country"`

--- a/apis/oauth/oauth.go
+++ b/apis/oauth/oauth.go
@@ -66,7 +66,7 @@ See: https://developers.weixin.qq.com/doc/offiaccount/OA_Web_Apps/Wechat_webpage
 func GetAuthorizeUrl(appid string, redirectUri string, scope string, state string) (authorizeUrl string) {
 	params := url.Values{}
 	params.Add("appid", appid)
-	params.Add("redirectUri", redirectUri)
+	params.Add("redirect_uri", redirectUri)
 	params.Add("scope", scope)
 	params.Add("state", state)
 	return OauthAuthorizeServerUrl + apiAuthorize + "?" + params.Encode()

--- a/client.go
+++ b/client.go
@@ -45,14 +45,14 @@ type Client struct {
 
 // HTTPGet GET 请求
 func (client *Client) HTTPGet(uri string) (resp []byte, err error) {
-	uri, err = client.applyAccessToken(uri)
+	newUrl, err := client.applyAccessToken(uri)
 	if err != nil {
 		return
 	}
 	if client.Ctx.Logger != nil {
 		client.Ctx.Logger.Printf("GET %s", uri)
 	}
-	response, err := http.Get(WXServerUrl + uri)
+	response, err := http.Get(WXServerUrl + newUrl)
 	if err != nil {
 		return
 	}
@@ -65,14 +65,14 @@ func (client *Client) HTTPGet(uri string) (resp []byte, err error) {
 			return
 		}
 
-		uri, err = client.applyAccessToken(uri)
+		newUrl, err = client.applyAccessToken(uri)
 		if err != nil {
 			return
 		}
 		if client.Ctx.Logger != nil {
-			client.Ctx.Logger.Printf("Refresh Access Token Second GET %s", uri)
+			client.Ctx.Logger.Printf("Refresh Access Token Second GET %s", newUrl)
 		}
-		response, err := http.Get(WXServerUrl + uri)
+		response, err := http.Get(WXServerUrl + newUrl)
 		if err != nil {
 			return
 		}
@@ -84,14 +84,14 @@ func (client *Client) HTTPGet(uri string) (resp []byte, err error) {
 
 //HTTPPost POST 请求
 func (client *Client) HTTPPost(uri string, payload io.Reader, contentType string) (resp []byte, err error) {
-	uri, err = client.applyAccessToken(uri)
+	newUrl, err := client.applyAccessToken(uri)
 	if err != nil {
 		return
 	}
 	if client.Ctx.Logger != nil {
 		client.Ctx.Logger.Printf("POST %s", uri)
 	}
-	response, err := http.Post(WXServerUrl+uri, contentType, payload)
+	response, err := http.Post(WXServerUrl+newUrl, contentType, payload)
 	if err != nil {
 		return
 	}
@@ -104,14 +104,14 @@ func (client *Client) HTTPPost(uri string, payload io.Reader, contentType string
 			return
 		}
 
-		uri, err = client.applyAccessToken(uri)
+		newUrl, err = client.applyAccessToken(uri)
 		if err != nil {
 			return
 		}
 		if client.Ctx.Logger != nil {
-			client.Ctx.Logger.Printf("Refresh Access Token Second POST %s", uri)
+			client.Ctx.Logger.Printf("Refresh Access Token Second POST %s", newUrl)
 		}
-		response, err := http.Post(WXServerUrl+uri, contentType, payload)
+		response, err := http.Post(WXServerUrl+newUrl, contentType, payload)
 		if err != nil {
 			return
 		}

--- a/client.go
+++ b/client.go
@@ -168,12 +168,10 @@ func responseFilter(response *http.Response) (resp []byte, err error) {
 		err = NeedRefreshAccessTokenError
 		return
 	}
-
 	if errorResponse.Errcode != 0 {
 		err = errors.New(string(resp))
 		return
 	}
-
 	return
 }
 

--- a/offiaccount.go
+++ b/offiaccount.go
@@ -30,6 +30,9 @@ import (
 // GetAccessTokenFunc 获取 access_token 方法接口
 type GetAccessTokenFunc func(ctx *OffiAccount) (accessToken string, err error)
 
+// NoticeRefreshAccessTokenFunc 通知中控 刷新 access_token
+type NoticeRefreshAccessTokenFunc func(ctx *OffiAccount) (accessToken string, err error)
+
 /*
 OffiAccount 公众号实例
 */
@@ -45,8 +48,9 @@ type OffiAccount struct {
 AccessToken 管理器 处理缓存 和 刷新 逻辑
 */
 type AccessToken struct {
-	Cache                 cachego.Cache
-	GetAccessTokenHandler GetAccessTokenFunc
+	Cache                        cachego.Cache
+	GetAccessTokenHandler        GetAccessTokenFunc
+	GetRefreshAccessTokenHandler NoticeRefreshAccessTokenFunc
 }
 
 /*
@@ -66,8 +70,9 @@ func New(config Config) (offiAccount *OffiAccount) {
 	instance := OffiAccount{
 		Config: config,
 		AccessToken: AccessToken{
-			Cache:                 file.New(os.TempDir()),
-			GetAccessTokenHandler: GetAccessToken,
+			Cache:                        file.New(os.TempDir()),
+			GetAccessTokenHandler:        GetAccessToken,
+			GetRefreshAccessTokenHandler: NoticeRefreshAccessToken,
 		},
 	}
 


### PR DESCRIPTION
简单想法：

1. 在 AccessToken 结构体中添加了一个 GetRefreshAccessTokenHandler 方法，在这可以去做一些更新access-token的逻辑，也可以通知中控服务-access-token已失效，此时本地已缓存最新的access-token；

2. 在 client 模块中 responseFilter 新增access-token微信失效错误判断

3. 在 HTTPGet\HTTPPost 中 识别 NeedRefreshAccessTokenError，只处理一次微信access-token失效错误，避免因为人工配置错误导致的死循环；

——
以上是我的粗糙想法，不知道会不会影响您对该项目其他的设计想法，还请辛苦review，谢谢；
